### PR TITLE
Increase the limit of max open files

### DIFF
--- a/Source/ExampleConfig/pcap_dnsproxy.service.plist
+++ b/Source/ExampleConfig/pcap_dnsproxy.service.plist
@@ -17,5 +17,10 @@
 			<key>SuccessfulExit</key>
 			<false/>
 		</dict>
+		<key>SoftResourceLimits</key>
+		<dict>
+			<key>NumberOfFiles</key>
+			<integer>10240</integer>
+		</dict>
 	</dict>
 </plist>


### PR DESCRIPTION
OSX default is 256 which often cause Network Error: Socket initialization error, error code is 24.